### PR TITLE
Sanity fixes

### DIFF
--- a/GameData/zKerbalismSystemHeat/Patches/ModSupport/NearFutureElectrical.cfg
+++ b/GameData/zKerbalismSystemHeat/Patches/ModSupport/NearFutureElectrical.cfg
@@ -1,0 +1,21 @@
+// Do not let Kerbalism touch NFE Nuclear Recycler
+@PART[nuclear-recycler-25]:NEEDS[Kerbalism,SystemHeat,NearFutureElectrical]:AFTER[NearFutureElectrical]
+{
+	@MODULE[ModuleResourceConverter],*
+	{
+		@name = SystemHeatConverterKerbalism
+	}
+}
+@PART[nuclear-recycler-25]:NEEDS[Kerbalism,SystemHeat,NearFutureElectrical]:BEFORE[SystemHeat]
+{
+	@MODULE[SystemHeatConverterKerbalism],*
+	{
+		@name = ModuleResourceConverter
+	}
+
+	!MODULE[ProcessController],* {}
+	!MODULE[Configure],* {}
+	!MODULE[Planner],* {}
+
+	!MODULE[Reliability]:HAS[#type[ProcessController]] {}
+}

--- a/GameData/zKerbalismSystemHeat/Patches/SystemHeatConverters.cfg
+++ b/GameData/zKerbalismSystemHeat/Patches/SystemHeatConverters.cfg
@@ -43,7 +43,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[Reliability]:HAS[#type[ModuleResourceConverter]]]:NEEDS[FeatureReliability,SystemHeat]:FOR[zzzz_SystemHeat]
+@PART[*]:HAS[@MODULE[SystemHeatConverterKerbalism],@MODULE[Reliability]:HAS[#type[ModuleResourceConverter]]]:NEEDS[FeatureReliability,SystemHeat]:FOR[zzzz_SystemHeat]
 {
 	@MODULE[Reliability]:HAS[#type[ModuleResourceConverter]]
 	{

--- a/GameData/zKerbalismSystemHeat/Patches/SystemHeatHarvesters.cfg
+++ b/GameData/zKerbalismSystemHeat/Patches/SystemHeatHarvesters.cfg
@@ -43,7 +43,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[Reliability]:HAS[#type[ModuleResourceHarvester]]]:NEEDS[FeatureReliability,SystemHeat]:FOR[zzzz_SystemHeat]
+@PART[*]:HAS[@MODULE[SystemHeatHarvesterKerbalism],@MODULE[Reliability]:HAS[#type[ModuleResourceHarvester]]]:NEEDS[FeatureReliability,SystemHeat]:FOR[zzzz_SystemHeat]
 {
 	@MODULE[Reliability]:HAS[#type[ModuleResourceHarvester]]
 	{


### PR DESCRIPTION
to avoid having 
```
		MODULE
		{
			name = Reliability
			type = SystemHeatConverterKerbalism
```
together with
```
		MODULE
		{
			name = ModuleResourceConverter
```
and alike.


I struggled with the usefulness of GameData\zKerbalismSystemHeat\Patches\ModsSupport\NearFutureElectrical.cfg
1st: it contained a :FOR[NearFutureElectrical] - which is a no-go.
2nd: why? First it converts ModuleResourceConverter to SystemHeatConverterKerbalism, then it reverts it by converting SystemHeatConverterKerbalism to ModuleResourceConverter.